### PR TITLE
Make iterating over full product names more symmetric to branch tree traversal.

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,10 +104,9 @@ func (uf *urlFinder) findURLs(adv *csaf.Advisory) {
 	// First iterate over full product names.
 	if names := tree.FullProductNames; names != nil {
 		for _, name := range *names {
-			if name == nil || name.ProductID == nil {
-				continue
+			if name != nil && name.ProductID != nil {
+				add(slices.Index(uf.ids, *name.ProductID), name.ProductIdentificationHelper)
 			}
-			add(slices.Index(uf.ids, *name.ProductID), name.ProductIdentificationHelper)
 		}
 	}
 


### PR DESCRIPTION
Forget to push on last PR